### PR TITLE
[Build][Test]: add container support, unit test

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -41,13 +41,12 @@ tests/build/*
 *.app
 
 ### VisualStudioCode template
-.vscode/
+.vscode/*
 !.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
 *.code-workspace
-.idea/
 
 # Local History for Visual Studio Code
 .history/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+FROM gcc:12.2
+LABEL maintainer="ChiaMin chiaminchung@gmail.com, TaoLin tanlin2013@gmail.com"
+
+ARG WORKDIR=/home
+ARG PKGDIR=/root
+
+# Set up compiling flags for ITensor
+ENV CCCOM="g++ -m64 -std=c++17 -fconcepts -fPIC" \
+    PLATFORM="lapack" \
+    BLAS_LAPACK_LIBFLAGS="-lpthread -L/usr/lib -lblas -llapack"
+
+# Install cmake, lapack, blas
+RUN apt update && \
+    apt-get install -y --no-install-recommends \
+    cmake \
+    liblapack-dev \
+    liblapacke-dev \
+    libopenblas-dev
+
+# Install ITensor
+RUN git clone --branch v3 https://github.com/ITensor/ITensor.git $PKGDIR/itensor && \
+    cd $PKGDIR/itensor && \
+    cp options.mk.sample options.mk && \
+    make -e
+
+# Install 3rd party ITensor utilities
+RUN git clone https://github.com/chiamin/itensor.utility.git $PKGDIR/itensor.utility
+
+# Install Catch2 framework for unit test
+RUN git clone https://github.com/catchorg/Catch2.git $PKGDIR/catch2 && \
+    cd $PKGDIR/catch2 && \
+    cmake -Bbuild -H. -DBUILD_TESTING=OFF && \
+    cmake --build build/ --target install
+
+RUN apt-get -y clean && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR $WORKDIR
+COPY . $WORKDIR
+
+ENTRYPOINT /bin/bash

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required( VERSION 3.10 )
+
+project( Unittest LANGUAGES CXX )
+
+set( ITENSOR_DIR "/root/itensor" )
+
+# Include 3rd party ITensor utilities
+include_directories( ${ITENSOR_DIR}/ "/root/itensor.utility/" )
+
+# Include Itensor library
+add_library( itensor STATIC IMPORTED )
+set_property( TARGET
+    itensor PROPERTY IMPORTED_LOCATION ${ITENSOR_DIR}/lib/libitensor.a
+)
+
+# Define sources and output executable
+add_executable( test.exe
+    test_one_particle_basis.cpp
+)
+
+# Include Catch2 framework for unit test
+find_package(Catch2 3 REQUIRED)
+
+# Link executable with libraries
+set( ITENSOR_LIBFLAGS "-lpthread -L/usr/lib -lblas -llapack -fopenmp" )
+target_link_libraries( test.exe
+    PRIVATE itensor "${ITENSOR_LIBFLAGS}" Catch2::Catch2WithMain
+)

--- a/tests/test_one_particle_basis.cpp
+++ b/tests/test_one_particle_basis.cpp
@@ -1,0 +1,32 @@
+#include <catch2/catch_all.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+#include "itensor/all.h"
+
+#include "../kbasis/OneParticleBasis.h"
+
+using namespace itensor;
+using namespace Catch;
+
+
+TEST_CASE ( "Check matrix elements of tight-binding Hamiltonian", "[tight_binding_Hamilt]" ){
+    int mat_dim = 4;
+    auto mat = tight_binding_Hamilt(mat_dim, 0.5, 1.);
+    float expected_mat[4][4] = {
+        {-1.0, -0.5, 0.0, 0.0},
+        {-0.5, -1.0, -0.5, 0.0},
+        {0.0, -0.5, -1.0, -0.5},
+        {0.0, 0.0, -0.5, -1.0}
+    };
+
+    for (int i = 0; i < mat_dim; i++){
+        for (int j = 0; j < mat_dim; j++){
+            CHECK( mat(i, j) == Approx(expected_mat[i][j]).epsilon(1e-12) );
+        }
+    }
+}
+
+
+// TEST_CASE ( "Check one particle basis", ){
+
+// }


### PR DESCRIPTION
Hi ChiaMin,

Here comes 2 new major features that could make life easier for dev:

* Docker container support 
* Unit test via Catch2 framework

Docker
-------
* Base image: [gcc](https://hub.docker.com/_/gcc)
* Additionally installed packages:
   1. cmake
   2. lapack, blas
   3. [itensor](https://github.com/ITensor/ITensor)
   4. [itensor.utility](https://github.com/chiamin/itensor.utility)
   5. [catch2](https://github.com/catchorg/Catch2)
* Built-in environment variables:
   The compiling flags for *ITensor*,
   1. ```CCCOM="g++ -m64 -std=c++17 -fconcepts -fPIC"```
   2. ```PLATFORM="lapack"```
   3. ```BLAS_LAPACK_LIBFLAGS="-lpthread -L/usr/lib -lblas -llapack"```

I prefer not to edit the flags directly in ```itensor/options.mk``` during docker build, that could easily make mistakes, but instead overwrite them from the environment variables, e.g. with ```make -e```. Unless we want to put a custom version of ```options.mk``` in this repo, so we could just copy it.

Catch2
-------
[Catch2](https://github.com/catchorg/Catch2) is also the framework that *ITensor* adopted for unit test. It requires to compile the sources with cmake.

To compile the tests, one can do (in ```/tests/``` folder)
```
cmake -B build
cd build
make
```

The resulting executable is ```test.exe``` (in ```/tests/build/```).

Proposal
---------
- [x] Later, maybe we could put the test pipeline in Github Actions (CI/CD).
-- (finished in https://github.com/chiamin/HybridLeads/pull/2)