### PR TITLE
Test: use catch2 macro & cmake muiti-tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
       image: ghcr.io/${{ github.actor }}/hybridleads:main
     steps:
       - uses: actions/checkout@v3
-      
+
       - name: Set up building directory
         run: |
           echo "build_dir=tests/build" >> $GITHUB_ENV
@@ -25,4 +25,6 @@ jobs:
 
       - name: Unit Test
         run: |
-          ./${{ env.build_dir }}/test.exe
+          for filename in ${{ env.build_dir }}/test_*.exe; do
+            ./"$filename"
+          done

--- a/kbasis/Hamiltonian.h
+++ b/kbasis/Hamiltonian.h
@@ -1,207 +1,292 @@
 #ifndef __HAMILTONIAN_H_CMC__
 #define __HAMILTONIAN_H_CMC__
 
-// C(i1,dag1) * C(i2,dag2) = \sum_k1 coef_i1,k1 C(k1,dag'1) * \sum_k2 coef_i2,k2 C(k2,dag'2)
-// Return: vector of (coef, k1, dag'1, k2, dag'2)
+#include "GeneralUtility.h"
+#include "OneParticleBasis.h"
+#include "SortBasis.h"
+#include "itensor/all.h"
+
+using namespace itensor;
+using namespace std;
+
+/**
+ * @brief Collecting operator information in the new basis.
+ * C(i1,dag1) * C(i2,dag2) = \sum_k1 coef_i1,k1 C(k1,dag'1) * \sum_k2 coef_i2,k2
+ * C(k2,dag'2)
+ *
+ * @tparam Basis1
+ * @tparam Basis2
+ * @param basis1
+ * @param basis2
+ * @param i1
+ * @param i2
+ * @param dag1
+ * @param dag2
+ * @param cutoff
+ * @return vector <tuple <auto,int,bool,int,bool>> vector of (coef, k1, dag'1,
+ * k2, dag'2), where \f$coef = coef_{i1,k1} * coef_{i2,k2}\f$.
+ */
 template <typename Basis1, typename Basis2>
-vector <tuple <auto,int,bool,int,bool>>
-quadratic_operator_new (const Basis1& basis1, const Basis2& basis2, int i1, int i2, bool dag1, bool dag2, Real cutoff=1e-16)
-{
-    auto C1 = basis1.C_op (i1, dag1);     // i -> k, coef, dag
-    auto C2 = basis2.C_op (i2, dag2);
+vector<tuple<auto, int, bool, int, bool>> quadratic_operator_new(
+    const Basis1& basis1, const Basis2& basis2, int i1, int i2, bool dag1,
+    bool dag2, Real cutoff = 1e-16) {
+  auto C1 = basis1.C_op(i1, dag1);  // i -> k, coef, dag
+  auto C2 = basis2.C_op(i2, dag2);
 
-    vector<tuple <Real,int,bool,int,bool>> ops;             // coef, k1, dag1, k2, dag2
-    for(auto&& [k1,c1,dag1p] : C1)
-    {
-        for(auto&& [k2,c2,dag2p] : C2)
-        {
-            auto coef = c1*c2;
-            if (abs(coef) > cutoff)
-                ops.emplace_back (coef,k1,dag1p,k2,dag2p);    // Cdag_ki1 C_ki2
-        }
+  vector<tuple<Real, int, bool, int, bool>> ops;  // coef, k1, dag1, k2, dag2
+  for (auto&& [k1, c1, dag1p] : C1) {
+    for (auto&& [k2, c2, dag2p] : C2) {
+      auto coef = c1 * c2;
+      if (abs(coef) > cutoff)
+        ops.emplace_back(coef, k1, dag1p, k2, dag2p);  // Cdag_ki1 C_ki2
     }
-    return ops;
+  }
+  return ops;
 }
 
-// Add Cdagger_i1 C_i2 into AutoMPO ampo.
-// Here i1 and i2 are two sites in real space
+/**
+ * @brief Add Cdagger_i1 C_i2 into AutoMPO object.
+ * Here i1 and i2 are two sites in real space.
+ *
+ * @tparam Basis1
+ * @tparam Basis2
+ * @tparam NumType
+ * @param ampo The AutoMPO object.
+ * @param basis1
+ * @param basis2
+ * @param i1 The 1st site in real space.
+ * @param i2 The 2nd site in real space.
+ * @param coef
+ * @param to_glob
+ */
 template <typename Basis1, typename Basis2, typename NumType>
-void add_CdagC (AutoMPO& ampo, const Basis1& basis1, const Basis2& basis2, int i1, int i2, NumType coef, const ToGlobDict& to_glob)
-{
-    if (i1 < 0) i1 += basis1.size() + 1;
-    if (i2 < 0) i2 += basis2.size() + 1;
-    vector <tuple <auto,int,bool,int,bool>> terms = quadratic_operator_new (basis1, basis2, i1, i2, true, false);
+void add_CdagC(AutoMPO& ampo, const Basis1& basis1, const Basis2& basis2,
+               int i1, int i2, NumType coef, const ToGlobDict& to_glob) {
+  if (i1 < 0) i1 += basis1.size() + 1;
+  if (i2 < 0) i2 += basis2.size() + 1;
+  vector<tuple<auto, int, bool, int, bool>> terms =
+      quadratic_operator_new(basis1, basis2, i1, i2, true, false);
 
-    string p1 = basis1.name(),
-           p2 = basis2.name();
-    // Hopping terms
-    for(auto [c12, k1, dag1, k2, dag2] : terms)  // coef, k1, dag1, k2, dag2
-    {
-        int j1 = to_glob.at({p1,k1});
-        int j2 = to_glob.at({p2,k2});
-        string op1 = (dag1 ? "Cdag" : "C");
-        string op2 = (dag2 ? "Cdag" : "C");
-        Real c = coef * c12;
-        ampo += c, op1, j1, op2, j2;
-    }
+  string p1 = basis1.name(), p2 = basis2.name();
+  // Hopping terms
+  for (auto [c12, k1, dag1, k2, dag2] : terms)  // coef, k1, dag1, k2, dag2
+  {
+    int j1 = to_glob.at({p1, k1});
+    int j2 = to_glob.at({p2, k2});
+    string op1 = (dag1 ? "Cdag" : "C");
+    string op2 = (dag2 ? "Cdag" : "C");
+    Real c = coef * c12;
+    ampo += c, op1, j1, op2, j2;
+  }
 }
 
-// Add Cdagger_i1 C_i2 into AutoMPO ampo.
-// Here i1 and i2 are two sites in real space
+/**
+ * @brief Add Cdagger_i1 C_i2 into AutoMPO object.
+ * Here i1 and i2 are two sites in real space.
+ *
+ * @tparam Basis1
+ * @tparam Basis2
+ * @tparam NumType
+ * @param ampo The AutoMPO object
+ * @param basis1
+ * @param basis2
+ * @param i1
+ * @param i2
+ * @param coef
+ * @param to_glob
+ */
 template <typename Basis1, typename Basis2, typename NumType>
-void add_CdagC_charge (AutoMPO& ampo, const Basis1& basis1, const Basis2& basis2, int i1, int i2, NumType coef, const ToGlobDict& to_glob)
-{
-    if (i1 < 0) i1 += basis1.size() + 1;
-    if (i2 < 0) i2 += basis2.size() + 1;
-    vector <tuple <auto,int,bool,int,bool>> terms = quadratic_operator_new (basis1, basis2, i1, i2, true, false);
+void add_CdagC_charge(AutoMPO& ampo, const Basis1& basis1, const Basis2& basis2,
+                      int i1, int i2, NumType coef, const ToGlobDict& to_glob) {
+  if (i1 < 0) i1 += basis1.size() + 1;
+  if (i2 < 0) i2 += basis2.size() + 1;
+  vector<tuple<auto, int, bool, int, bool>> terms =
+      quadratic_operator_new(basis1, basis2, i1, i2, true, false);
 
-    // 
-    string p1 = basis1.name(),
-           p2 = basis2.name();
-    string op_charge = "";
-    if ((p1 == "L" and p2 == "S") or    // Cdag_L C_S
-        (p1 == "R" and p2 == "S"))      // Cdag_R C_S
-    {
-        op_charge = "A";
+  //
+  string p1 = basis1.name(), p2 = basis2.name();
+  string op_charge = "";
+  if ((p1 == "L" and p2 == "S") or  // Cdag_L C_S
+      (p1 == "R" and p2 == "S"))    // Cdag_R C_S
+  {
+    op_charge = "A";
+  } else if ((p1 == "S" and p2 == "L") or  // Cdag_S C_L
+             (p1 == "S" and p2 == "R"))    // Cdag_S C_R
+  {
+    op_charge = "Adag";
+  }
+  // Hopping terms
+  int jc = to_glob.at({"C", 1});
+  for (auto [c12, k1, dag1, k2, dag2] : terms)  // coef, k1, dag1, k2, dag2
+  {
+    int j1 = to_glob.at({p1, k1});
+    int j2 = to_glob.at({p2, k2});
+    string op1 = (dag1 ? "Cdag" : "C");
+    string op2 = (dag2 ? "Cdag" : "C");
+    Real c = coef * c12;
+    // hopping
+    if (op_charge != "") {
+      ampo += c, op1, j1, op_charge, jc, op2, j2;
+    } else {
+      ampo += c, op1, j1, op2, j2;
     }
-    else if ((p1 == "S" and p2 == "L") or    // Cdag_S C_L
-             (p1 == "S" and p2 == "R"))      // Cdag_S C_R
-    {
-        op_charge = "Adag";
-    }
-    // Hopping terms
-    int jc = to_glob.at({"C",1});
-    for(auto [c12, k1, dag1, k2, dag2] : terms)  // coef, k1, dag1, k2, dag2
-    {
-        int j1 = to_glob.at({p1,k1});
-        int j2 = to_glob.at({p2,k2});
-        string op1 = (dag1 ? "Cdag" : "C");
-        string op2 = (dag2 ? "Cdag" : "C");
-        Real c = coef * c12;
-        // hopping
-        if (op_charge != "")
-        {
-            ampo += c, op1, j1, op_charge, jc, op2, j2;
-        }
-        else
-        {
-            ampo += c, op1, j1, op2, j2;
-        }
-    }
+  }
 }
 
-// Add -Delta C_i C_i+1 + h.c.
+/**
+ * @brief Add -Delta C_i C_i+1 + h.c.
+ *
+ * @tparam Basis1
+ * @tparam Basis2
+ * @tparam NumType
+ * @param ampo
+ * @param basis1
+ * @param basis2
+ * @param i1
+ * @param i2
+ * @param Delta
+ * @param to_glob
+ */
 template <typename Basis1, typename Basis2, typename NumType>
-void add_SC (AutoMPO& ampo, const Basis1& basis1, const Basis2& basis2, int i1, int i2, NumType Delta, const ToGlobDict& to_glob)
-{
-    if (i1 < 0) i1 += basis1.size()+1;
-    if (i2 < 0) i2 += basis2.size()+1;
-    vector <tuple <auto,int,bool,int,bool>> terms = quadratic_operator_new (basis1, basis2, i1, i2, false, false);
+void add_SC(AutoMPO& ampo, const Basis1& basis1, const Basis2& basis2, int i1,
+            int i2, NumType Delta, const ToGlobDict& to_glob) {
+  if (i1 < 0) i1 += basis1.size() + 1;
+  if (i2 < 0) i2 += basis2.size() + 1;
+  vector<tuple<auto, int, bool, int, bool>> terms =
+      quadratic_operator_new(basis1, basis2, i1, i2, false, false);
 
-    string p1 = basis1.name(),
-           p2 = basis2.name();
-    for(auto [c12, k1, dag1, k2, dag2] : terms)  // coef, k1, dag1, k2, dag2
-    {
-        int j1 = to_glob.at({p1,k1});
-        int j2 = to_glob.at({p2,k2});
-        if (j1 != j2)
-        {
-            auto c = Delta * c12;
-            auto cc = iut::conj (c);
-            ampo += -c, "C", j1, "C", j2;
-            ampo += -cc, "Cdag", j2, "Cdag", j1;
-        }
+  string p1 = basis1.name(), p2 = basis2.name();
+  for (auto [c12, k1, dag1, k2, dag2] : terms)  // coef, k1, dag1, k2, dag2
+  {
+    int j1 = to_glob.at({p1, k1});
+    int j2 = to_glob.at({p2, k2});
+    if (j1 != j2) {
+      auto c = Delta * c12;
+      auto cc = iut::conj(c);
+      ampo += -c, "C", j1, "C", j2;
+      ampo += -cc, "Cdag", j2, "Cdag", j1;
     }
+  }
 }
 
-template <typename BasisL, typename BasisR, typename BasisS, typename BasisC, typename SiteType, typename Para>
-AutoMPO get_ampo_Kitaev_chain (const BasisL& leadL, const BasisR& leadR, const BasisS& scatterer, const BasisC& charge, const SiteType& sites, const Para& para, const ToGlobDict& to_glob)
-{
-    mycheck (length(sites) == to_glob.size(), "size not match");
+/**
+ * @brief Get AutoMPO object for Kitaev chain
+ *
+ * @tparam BasisL
+ * @tparam BasisR
+ * @tparam BasisS
+ * @tparam BasisC
+ * @tparam SiteType
+ * @tparam Para
+ * @param leadL
+ * @param leadR
+ * @param scatterer
+ * @param charge
+ * @param sites
+ * @param para
+ * @param to_glob
+ * @return AutoMPO
+ */
+template <typename BasisL, typename BasisR, typename BasisS, typename BasisC,
+          typename SiteType, typename Para>
+AutoMPO get_ampo_Kitaev_chain(const BasisL& leadL, const BasisR& leadR,
+                              const BasisS& scatterer, const BasisC& charge,
+                              const SiteType& sites, const Para& para,
+                              const ToGlobDict& to_glob) {
+  mycheck(length(sites) == to_glob.size(), "size not match");
 
-    AutoMPO ampo (sites);
+  AutoMPO ampo(sites);
 
-    // Diagonal terms, including the non-interacting and the SC couplings
-    string sname = scatterer.name();
-    auto add_diag = [&ampo, &to_glob, &sname] (const auto& basis)
-    {
-        string p = basis.name();
-        for(int i = 1; i <= basis.size(); i++)
-        {
-            int j = to_glob.at({p,i});
-            auto en = basis.en(i);
-            ampo += en, "N", j;
-            if (p == sname)
-            {
-                auto mu = basis.mu(i);
-                ampo += -0.5 * (en + mu), "I", i;
-            }
-        }
-    };
-    add_diag (leadL);
-    add_diag (leadR);
-    add_diag (scatterer);
-
-    // Contact hopping
-    add_CdagC (ampo, leadL, scatterer, -1, 1, -para.tcL, to_glob);
-    add_CdagC (ampo, scatterer, leadL, 1, -1, -para.tcL, to_glob);
-    add_CdagC (ampo, leadR, scatterer, 1, -1, -para.tcR, to_glob);
-    add_CdagC (ampo, scatterer, leadR, -1, 1, -para.tcR, to_glob);
-
-    // Charging energy
-    string cname = charge.name();
-    if (para.Ec != 0.)
-    {
-        int jc = to_glob.at({cname,1});
-        ampo += para.Ec,"NSqr",jc;
-        ampo += para.Ec * para.Ng * para.Ng, "I", jc;
-        ampo += -2.*para.Ec * para.Ng, "N", jc;
+  // Diagonal terms, including the non-interacting and the SC couplings
+  string sname = scatterer.name();
+  auto add_diag = [&ampo, &to_glob, &sname](const auto& basis) {
+    string p = basis.name();
+    for (int i = 1; i <= basis.size(); i++) {
+      int j = to_glob.at({p, i});
+      auto en = basis.en(i);
+      ampo += en, "N", j;
+      if (p == sname) {
+        auto mu = basis.mu(i);
+        ampo += -0.5 * (en + mu), "I", i;
+      }
     }
+  };
+  add_diag(leadL);
+  add_diag(leadR);
+  add_diag(scatterer);
 
-    // Josephson hopping
-    if (para.EJ != 0.)
-    {
-        int jc = to_glob.at({cname,1});
-        ampo += para.EJ,"A2",jc;
-        ampo += para.EJ,"A2dag",jc;
-    }
-    return ampo;
+  // Contact hopping
+  add_CdagC(ampo, leadL, scatterer, -1, 1, -para.tcL, to_glob);
+  add_CdagC(ampo, scatterer, leadL, 1, -1, -para.tcL, to_glob);
+  add_CdagC(ampo, leadR, scatterer, 1, -1, -para.tcR, to_glob);
+  add_CdagC(ampo, scatterer, leadR, -1, 1, -para.tcR, to_glob);
+
+  // Charging energy
+  string cname = charge.name();
+  if (para.Ec != 0.) {
+    int jc = to_glob.at({cname, 1});
+    ampo += para.Ec, "NSqr", jc;
+    ampo += para.Ec * para.Ng * para.Ng, "I", jc;
+    ampo += -2. * para.Ec * para.Ng, "N", jc;
+  }
+
+  // Josephson hopping
+  if (para.EJ != 0.) {
+    int jc = to_glob.at({cname, 1});
+    ampo += para.EJ, "A2", jc;
+    ampo += para.EJ, "A2dag", jc;
+  }
+  return ampo;
 }
 
-template <typename BasisL, typename BasisR, typename BasisS, typename SiteType, typename Para>
-AutoMPO get_ampo_tight_binding (const BasisL& leadL, const BasisR& leadR, const BasisS& scatterer, const SiteType& sites, const Para& para, const ToGlobDict& to_glob)
-{
-    mycheck (length(sites) == to_glob.size(), "size not match");
+/**
+ * @brief Get AutoMPO object for tight-binding model
+ *
+ * @tparam BasisL
+ * @tparam BasisR
+ * @tparam BasisS
+ * @tparam SiteType
+ * @tparam Para
+ * @param leadL
+ * @param leadR
+ * @param scatterer
+ * @param sites
+ * @param para
+ * @param to_glob
+ * @return AutoMPO
+ */
+template <typename BasisL, typename BasisR, typename BasisS, typename SiteType,
+          typename Para>
+AutoMPO get_ampo_tight_binding(const BasisL& leadL, const BasisR& leadR,
+                               const BasisS& scatterer, const SiteType& sites,
+                               const Para& para, const ToGlobDict& to_glob) {
+  mycheck(length(sites) == to_glob.size(), "size not match");
 
-    AutoMPO ampo (sites);
+  AutoMPO ampo(sites);
 
-    // Non-interacting terms
-    string sname = scatterer.name();
-    auto add_diag = [&ampo, &to_glob, &sname] (const auto& basis)
-    {
-        string p = basis.name();
-        for(int i = 1; i <= basis.size(); i++)
-        {
-            int j = to_glob.at({p,i});
-            auto en = basis.en(i);
-            ampo += en, "N", j;
-        }
-    };
-    add_diag (leadL);
-    add_diag (leadR);
-    add_diag (scatterer);
-
-    // Contact hopping
-    if (para.tcL != 0.)
-    {
-        add_CdagC (ampo, leadL, scatterer, -1, 1, -para.tcL, to_glob);
-        add_CdagC (ampo, scatterer, leadL, 1, -1, -para.tcL, to_glob);
+  // Non-interacting terms
+  string sname = scatterer.name();
+  auto add_diag = [&ampo, &to_glob, &sname](const auto& basis) {
+    string p = basis.name();
+    for (int i = 1; i <= basis.size(); i++) {
+      int j = to_glob.at({p, i});
+      auto en = basis.en(i);
+      ampo += en, "N", j;
     }
-    if (para.tcR != 0.)
-    {
-        add_CdagC (ampo, leadR, scatterer, 1, -1, -para.tcR, to_glob);
-        add_CdagC (ampo, scatterer, leadR, -1, 1, -para.tcR, to_glob);
-    }
-    return ampo;
+  };
+  add_diag(leadL);
+  add_diag(leadR);
+  add_diag(scatterer);
+
+  // Contact hopping
+  if (para.tcL != 0.) {
+    add_CdagC(ampo, leadL, scatterer, -1, 1, -para.tcL, to_glob);
+    add_CdagC(ampo, scatterer, leadL, 1, -1, -para.tcL, to_glob);
+  }
+  if (para.tcR != 0.) {
+    add_CdagC(ampo, leadR, scatterer, 1, -1, -para.tcR, to_glob);
+    add_CdagC(ampo, scatterer, leadR, -1, 1, -para.tcR, to_glob);
+  }
+  return ampo;
 }
 #endif

--- a/kbasis/OneParticleBasis.h
+++ b/kbasis/OneParticleBasis.h
@@ -1,7 +1,9 @@
 #ifndef __ONEPARTICLEBASIS_H_CMC__
 #define __ONEPARTICLEBASIS_H_CMC__
+
 #include "GeneralUtility.h"
 #include "itensor/all.h"
+
 using namespace itensor;
 using namespace std;
 
@@ -10,11 +12,12 @@ using namespace std;
  *
  * @param L The size of matrix, L x L.
  * @param t The hopping strength.
- * @param mu On-site energy.
- * @param damp_fac
+ * @param mu The on-site energy.
+ * @param damp_fac The base of power law hopping. Default to 1 as taking no
+ * effect.
  * @param damp_from_right
- * @param verbose
- * @return Matrix The Hamiltonian.
+ * @param verbose Print out the matrix elements.
+ * @return Matrix The Hamiltonian matrix, which is tridiagonal.
  */
 Matrix tight_binding_Hamilt(int L, Real t, Real mu, Real damp_fac = 1.,
                             bool damp_from_right = true, bool verbose = false) {

--- a/kbasis/SortBasis.h
+++ b/kbasis/SortBasis.h
@@ -1,6 +1,11 @@
 #ifndef __SORTBASIS_H_CMC__
 #define __SORTBASIS_H_CMC__
 
+#include "itensor/all.h"
+
+using namespace itensor;
+using namespace std;
+
 using ToGlobDict =
     map<pair<string, int>, int>;  // {partition, ki} -> ortical index
 using ToLocDict =
@@ -47,8 +52,13 @@ vector<SortInfo> get_sort_info(const BasisT& basis, const Bases&... bases) {
 }
 // ----
 
-// Input: arbitrary number of bases
-// Combine all the basis states and sort by the energies
+/**
+ * @brief Combine all the basis states and sort by the energies
+ *
+ * @tparam Bases
+ * @param bases Arbitrary number of bases
+ * @return vector<SortInfo>
+ */
 template <typename... Bases>
 vector<SortInfo> sort_by_energy(const Bases&... bases) {
   vector<SortInfo> orbs = get_sort_info(bases...);

--- a/kbasis/note.md
+++ b/kbasis/note.md
@@ -1,1 +1,0 @@
-I have changed it to simulating tight-binding model, but need to check if the result is correct.

--- a/note.md
+++ b/note.md
@@ -1,9 +1,0 @@
-What to do:
-
-0. Create a 4-site MPO for tight-binding model. The first two sites are in real space and the last two sites are in k space. Find the ground state for N=2 by DMRG; check the energy is correct.
-
-1. Find the ground state of the left infinite tight-binding lead using iTDVP. Follow the code in itdvp/. Set mu=muL.
-
-2. Find the ground state of the right infinite tight-binding lead using iTDVP. Follow the code in itdvp/. Set mu=muR.
-
-3. 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,36 +4,44 @@ project(Unittest LANGUAGES CXX)
 
 set(ITENSOR_DIR "/root/itensor")
 
-# Include 3rd party ITensor utilities
-include_directories(${ITENSOR_DIR}/ "/root/itensor.utility/")
+# Include 3rd party headers from itensor.utility
+include_directories("/root/itensor.utility/")
 
 # Include Itensor library
 add_library(itensor STATIC IMPORTED)
 set_property(TARGET
     itensor PROPERTY IMPORTED_LOCATION ${ITENSOR_DIR}/lib/libitensor.a
 )
+include_directories(${ITENSOR_DIR}/)
 
 # Include armadillo
 find_package(Armadillo REQUIRED)
 include_directories(${ARMADILLO_INCLUDE_DIRS})
 
-# Define sources and output executable
-add_executable(test.exe
-    test_one_particle_basis.cpp
-)
-
-# Compiling flags
-target_compile_features(test.exe PRIVATE cxx_std_17)
-target_compile_options(test.exe PRIVATE -m64 -fconcepts -fPIC)
-target_link_libraries(test.exe PRIVATE pthread blas lapack)
-
 # Include Catch2 framework for unit test
 find_package(Catch2 3 REQUIRED)
 
-# Link executable with libraries
-set(ITENSOR_LIBFLAGS "-lpthread -L/usr/lib -lblas -llapack -fopenmp")
-target_link_libraries(test.exe
-    PRIVATE itensor "${ITENSOR_LIBFLAGS}"
-    ${ARMADILLO_LIBRARIES}
-    Catch2::Catch2WithMain
+# Name all your sources filename here without extension
+set(SOURCES_FILES
+    test_one_particle_basis
+    test_hamiltonian
 )
+foreach(name ${SOURCES_FILES})
+    # Define sources and output executable
+    add_executable(${name}.exe
+        ${name}.cpp
+    )
+
+    # Compiling flags
+    target_compile_features(${name}.exe PRIVATE cxx_std_17)
+    target_compile_options(${name}.exe PRIVATE -m64 -fconcepts -fPIC)
+    target_link_libraries(${name}.exe PRIVATE pthread blas lapack)
+    set(ITENSOR_LIBFLAGS "-lpthread -L/usr/lib -lblas -llapack -fopenmp")
+
+    # Link executable with libraries
+    target_link_libraries(${name}.exe
+        PRIVATE itensor "${ITENSOR_LIBFLAGS}"
+        ${ARMADILLO_LIBRARIES}
+        Catch2::Catch2WithMain
+    )
+endforeach()

--- a/tests/test_hamiltonian.cpp
+++ b/tests/test_hamiltonian.cpp
@@ -1,14 +1,69 @@
 #include <catch2/catch_all.hpp>
-#include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
-#include "itensor/all.h"
+#include <catch2/catch_test_macros.hpp>
 
 #include "../kbasis/Hamiltonian.h"
+#include "../kbasis/OneParticleBasis.h"
+#include "../kbasis/SortBasis.h"
+#include "itensor/all.h"
 
 using namespace itensor;
 using namespace Catch;
 
+struct Para {
+  Real tcL = 0., tcR = 0.;
+};
 
-TEST_CASE (){
-    auto ampo = get_ampo_tight_binding()
+TEST_CASE("Check adding CdagC into AutoMPO", "[add_CdagC]") {}
+
+TEST_CASE("Check AutoMPO of tight-binding model", "[get_ampo_tight_binding]") {
+  int N = 12;
+  auto t = 0.5;
+  auto mu = 0.1;
+  auto sites = Fermion(N);
+  ToGlobDict to_glob;
+  ToLocDict to_loc;
+  Para para;
+  para.tcL = t;
+  para.tcR = t;
+
+  // Construct AutoMPO in a hybrid basis jointed by 3 bases
+  OneParticleBasis left_basis("left_sys", N / 3, t, mu);
+  OneParticleBasis middle_basis("middle_sys", N / 3, t, mu);
+  OneParticleBasis right_basis("right_sys", N / 3, t, mu);
+  auto info = sort_by_energy(left_basis, right_basis, middle_basis);
+  std::tie(to_glob, to_loc) = make_orb_dicts(info);
+  auto ampo = get_ampo_tight_binding(left_basis, right_basis, middle_basis,
+                                     sites, para, to_glob);
+  auto H = toMPO(ampo);
+
+  // Construct AutoMPO in real-space basis
+  auto expected_ampo = AutoMPO(sites);
+  for (int i = 1; i <= N; ++i) {
+    expected_ampo += -mu, "N", i;
+  }
+  for (int i = 1; i < N; ++i) {
+    expected_ampo += -t, "Cdag", i, "C", i + 1;
+    expected_ampo += -t, "Cdag", i + 1, "C", i;
+  }
+  auto expected_H = toMPO(expected_ampo);
+
+  // Create a random starting MPS
+  auto state = InitState(sites);
+  for (auto i : range1(N)) {
+    if (i % 2 == 1)
+      state.set(i, "1");
+    else
+      state.set(i, "0");
+  }
+  auto psi0 = randomMPS(state);
+
+  // Run DMRG in 2 bases respectively
+  auto sweeps = Sweeps(8);
+  sweeps.maxdim() = 10, 20, 100, 200, 200;
+  sweeps.cutoff() = 1E-10;
+  auto [energy, psi] = dmrg(H, psi0, sweeps, {"Silent", true});
+  auto [expected_energy, expected_psi] =
+      dmrg(expected_H, psi0, sweeps, {"Silent", true});
+  CHECK(energy == Approx(expected_energy).epsilon(1e-8));
 }

--- a/tests/test_one_particle_basis.cpp
+++ b/tests/test_one_particle_basis.cpp
@@ -12,11 +12,13 @@ using namespace Catch;
 TEST_CASE("Check matrix elements of tight-binding Hamiltonian",
           "[tight_binding_Hamilt]") {
   int mat_dim = 4;
-  auto ham_elems = tight_binding_Hamilt(mat_dim, 0.5, 1.);
-  double expected_elems[4][4] = {{-1.0, -0.5, 0.0, 0.0},
-                                 {-0.5, -1.0, -0.5, 0.0},
-                                 {0.0, -0.5, -1.0, -0.5},
-                                 {0.0, 0.0, -0.5, -1.0}};
+  auto t = GENERATE(0.5, 1.0);
+  auto mu = GENERATE(0.0, 0.1);
+  auto ham_elems = tight_binding_Hamilt(mat_dim, t, mu);
+  double expected_elems[mat_dim][mat_dim] = {{-mu, -t, 0.0, 0.0},
+                                             {-t, -mu, -t, 0.0},
+                                             {0.0, -t, -mu, -t},
+                                             {0.0, 0.0, -t, -mu}};
   arma::mat ham_mat(&ham_elems(0, 0), mat_dim, mat_dim);
   arma::mat expected_mat(&expected_elems[0][0], mat_dim, mat_dim);
   CHECK(approx_equal(ham_mat, expected_mat, "absdiff", 1e-12));
@@ -27,14 +29,12 @@ TEST_CASE("Check one particle basis", "[OneParticleBasis]") {
   OneParticleBasis basis("test_hamlt", mat_dim, 0.5, 1.);
 
   auto k_coef = basis.C_op(3, false);
-
   for (auto& tuple : k_coef) {
     std::cout << get<0>(tuple) << " " << get<1>(tuple) << " " << get<2>(tuple)
               << std::endl;
   }
 
   k_coef = basis.C_op(4, false);
-
   for (auto& tuple : k_coef) {
     std::cout << get<0>(tuple) << " " << get<1>(tuple) << " " << get<2>(tuple)
               << std::endl;
@@ -44,7 +44,7 @@ TEST_CASE("Check one particle basis", "[OneParticleBasis]") {
 TEST_CASE("Check AutoMPO in real space basis", "[RealSpaceBasis]") {
   int N = 3;
   auto t = 0.5;
-  auto mu = 0.1;
+  auto mu = GENERATE(0.0, 0.1);
   auto sites = Fermion(N);
   auto ampo = AutoMPO(sites);
 
@@ -103,9 +103,9 @@ TEST_CASE("Check AutoMPO in real space basis", "[RealSpaceBasis]") {
 }
 
 TEST_CASE("Check AutoMPO in hybrid basis", "[HybridBasis]") {
-  int N = 8;
+  int N = GENERATE(8, 16, 20);
   auto t = 0.5;
-  auto mu = 0.1;
+  auto mu = GENERATE(0.0, 0.1);
   auto sites = Fermion(N);
   auto ampo = AutoMPO(sites);
 

--- a/tests/test_one_particle_basis.cpp
+++ b/tests/test_one_particle_basis.cpp
@@ -99,7 +99,7 @@ TEST_CASE("Check AutoMPO in real space basis", "[RealSpaceBasis]") {
   double min_en = *min_element(ens.begin(), ens.end());
 
   // Compare ED ground state energy with DMRG
-  CHECK(min_en == Approx(energy).epsilon(1e-12));
+  CHECK(min_en == Approx(energy).epsilon(1e-8));
 }
 
 TEST_CASE("Check AutoMPO in hybrid basis", "[HybridBasis]") {
@@ -156,11 +156,11 @@ TEST_CASE("Check AutoMPO in hybrid basis", "[HybridBasis]") {
   auto psi0 = randomMPS(state);
 
   // Run DMRG in 2 bases respectively
-  auto sweeps = Sweeps(5);
+  auto sweeps = Sweeps(8);
   sweeps.maxdim() = 10, 20, 100, 200, 200;
-  sweeps.cutoff() = 1E-8;
+  sweeps.cutoff() = 1E-10;
   auto [energy, psi] = dmrg(H, psi0, sweeps, {"Quiet", true});
   auto [expected_energy, expected_psi] =
       dmrg(expected_H, psi0, sweeps, {"Quiet", true});
-  CHECK(energy == Approx(expected_energy).epsilon(1e-12));
+  CHECK(energy == Approx(expected_energy).epsilon(1e-8));
 }

--- a/tests/test_one_particle_basis.cpp
+++ b/tests/test_one_particle_basis.cpp
@@ -90,7 +90,7 @@ TEST_CASE("Check AutoMPO in real space basis", "[RealSpaceBasis]") {
   auto sweeps = Sweeps(5);
   sweeps.maxdim() = 10, 20, 100, 200, 200;
   sweeps.cutoff() = 1E-8;
-  auto [energy, psi] = dmrg(H, psi0, sweeps, {"Quiet", true});
+  auto [energy, psi] = dmrg(H, psi0, sweeps, {"Silent", true});
 
   // Run exact diagonalization
   Matrix U;
@@ -186,8 +186,8 @@ TEST_CASE("Check AutoMPO in hybrid basis", "[HybridBasis]") {
   auto sweeps = Sweeps(8);
   sweeps.maxdim() = 10, 20, 100, 200, 200;
   sweeps.cutoff() = 1E-10;
-  auto [energy, psi] = dmrg(H, psi0, sweeps, {"Quiet", true});
+  auto [energy, psi] = dmrg(H, psi0, sweeps, {"Silent", true});
   auto [expected_energy, expected_psi] =
-      dmrg(expected_H, psi0, sweeps, {"Quiet", true});
+      dmrg(expected_H, psi0, sweeps, {"Silent", true});
   CHECK(energy == Approx(expected_energy).epsilon(1e-8));
 }

--- a/tests/test_one_particle_basis.cpp
+++ b/tests/test_one_particle_basis.cpp
@@ -109,91 +109,56 @@ TEST_CASE("Check AutoMPO in hybrid basis", "[HybridBasis]") {
   auto sites = Fermion(N);
   auto ampo = AutoMPO(sites);
 
-  // Prepare the basis transformation
-  auto elems = tight_binding_Hamilt(N, t, mu);
-  arma::mat ham_mat(&elems(0, 0), N, N);
-  arma::mat Uik = arma::eye(N, N);
-  arma::vec evals;
-  arma::mat evecs;
-  arma::mat sub_ham_mat = ham_mat.submat(0, 0, N / 2 - 1, N / 2 - 1);
-  eig_sym(evals, evecs, sub_ham_mat);
-  Uik.submat(0, 0, N / 2 - 1, N / 2 - 1) = evecs;
-  arma::mat hybrid_ham_mat = Uik.t() * ham_mat * Uik;
-
   // Construct AutoMPO in hybrid basis
-  // Note that AutoMPO uses 1-index
-  for (int i = 0; i < N; ++i) {
-    for (int j = 0; j < N; ++j) {
-      double coef = hybrid_ham_mat(i, j);
-      if (i == j) {
-        ampo += coef, "N", i + 1;
-      } else {
-        ampo += coef, "Cdag", i + 1, "C", j + 1;
+  // I. 1st approach
+  SECTION("Use basis transformation") {
+    auto elems = tight_binding_Hamilt(N, t, mu);
+    arma::mat ham_mat(&elems(0, 0), N, N);
+    arma::mat Uik = arma::eye(N, N);
+    arma::vec evals;
+    arma::mat evecs;
+    arma::mat sub_ham_mat = ham_mat.submat(0, 0, N / 2 - 1, N / 2 - 1);
+    eig_sym(evals, evecs, sub_ham_mat);
+    Uik.submat(0, 0, N / 2 - 1, N / 2 - 1) = evecs;
+    arma::mat hybrid_ham_mat = Uik.t() * ham_mat * Uik;
+
+    // Note that AutoMPO uses 1-index
+    for (int i = 0; i < N; ++i) {
+      for (int j = 0; j < N; ++j) {
+        double coef = hybrid_ham_mat(i, j);
+        if (i == j) {
+          ampo += coef, "N", i + 1;
+        } else {
+          ampo += coef, "Cdag", i + 1, "C", j + 1;
+        }
       }
     }
   }
-  auto H = toMPO(ampo);
 
-  // Construct AutoMPO in real-space basis
-  auto expected_ampo = AutoMPO(sites);
-  for (int i = 1; i <= N; ++i) {
-    expected_ampo += -mu, "N", i;
+  // II. 2nd approach
+  SECTION("Direct construction of AutoMPO with OneParticleBasis::C_op") {
+    OneParticleBasis basis("sub_sys", N / 2, t, mu);
+    // 1. The k-space part
+    for (int k = 1; k <= N / 2; ++k) {
+      auto coef = basis.en(k);
+      ampo += coef, "N", k;
+    }
+    // 2. The mixing part
+    auto coef = basis.C_op(N / 2, false);
+    for (int k = 1; k <= N / 2; ++k) {
+      ampo += -t * get<1>(coef[k - 1]), "Cdag", k, "C", N / 2 + 1;
+      ampo += -t * get<1>(coef[k - 1]), "Cdag", N / 2 + 1, "C", k;
+    }
+    // 3. The real-space part
+    for (int i = N / 2 + 1; i <= N; ++i) {
+      ampo += -mu, "N", i;
+    }
+    for (int i = N / 2 + 1; i < N; ++i) {
+      ampo += -t, "Cdag", i, "C", i + 1;
+      ampo += -t, "Cdag", i + 1, "C", i;
+    }
   }
-  for (int i = 1; i < N; ++i) {
-    expected_ampo += -t, "Cdag", i, "C", i + 1;
-    expected_ampo += -t, "Cdag", i + 1, "C", i;
-  }
-  auto expected_H = toMPO(expected_ampo);
 
-  // Create a random starting MPS
-  auto state = InitState(sites);
-  for (auto i : range1(N)) {
-    if (i % 2 == 1)
-      state.set(i, "1");
-    else
-      state.set(i, "0");
-  }
-  auto psi0 = randomMPS(state);
-
-  // Run DMRG in 2 bases respectively
-  auto sweeps = Sweeps(8);
-  sweeps.maxdim() = 10, 20, 100, 200, 200;
-  sweeps.cutoff() = 1E-10;
-  auto [energy, psi] = dmrg(H, psi0, sweeps, {"Quiet", true});
-  auto [expected_energy, expected_psi] =
-      dmrg(expected_H, psi0, sweeps, {"Quiet", true});
-  CHECK(energy == Approx(expected_energy).epsilon(1e-8));
-}
-
-TEST_CASE("Check AutoMPO in hybrid basis with OneParticleBasis::C_op",
-          "[HybridBasis2]") {
-  int N = GENERATE(8, 16, 20);
-  auto t = 0.5;
-  auto mu = GENERATE(0.0, 0.1);
-  auto sites = Fermion(N);
-  auto ampo = AutoMPO(sites);
-  OneParticleBasis basis("sub_sys", N / 2, t, mu);
-
-  // Construct AutoMPO in hybrid basis
-  // 1. The k-space part
-  for (int k = 1; k <= N / 2; ++k) {
-    auto coef = basis.en(k);
-    ampo += coef, "N", k;
-  }
-  // 2. The mixing part
-  auto coef = basis.C_op(N / 2, false);
-  for (int k = 1; k <= N / 2; ++k) {
-    ampo += -t * get<1>(coef[k - 1]), "Cdag", k, "C", N / 2 + 1;
-    ampo += -t * get<1>(coef[k - 1]), "Cdag", N / 2 + 1, "C", k;
-  }
-  // 3. The real-space part
-  for (int i = N / 2 + 1; i <= N; ++i) {
-    ampo += -mu, "N", i;
-  }
-  for (int i = N / 2 + 1; i < N; ++i) {
-    ampo += -t, "Cdag", i, "C", i + 1;
-    ampo += -t, "Cdag", i + 1, "C", i;
-  }
   auto H = toMPO(ampo);
 
   // Construct AutoMPO in real-space basis


### PR DESCRIPTION
Major
------
* Direct build of AutoMPO in the hybrid basis.
* Update package `itensor.utility` version.

Minor
------
* Use `GENERATE` and `SECTION` macro in the test.
* Refactor `CmakeLists.txt` to run against multiple tests.
* Fix floating-point tolerance to match with DMRG stopping criteria.
* Silent DMRG outputs in the tests.